### PR TITLE
Add macOS use launchctl service controller

### DIFF
--- a/bgmi/others/me.ricterz.bgmi.plist
+++ b/bgmi/others/me.ricterz.bgmi.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>KeepAlive</key>
+  <true/>
+  <key>Label</key>
+  <string>me.ricterz.bgmi</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/bgmi_http</string>
+    <string>--port=8888</string>
+    <string>--address=127.0.0.1</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>WorkingDirectory</key>
+  <string>/usr/local/bin</string>
+</dict>
+</plist>


### PR DESCRIPTION
Place this plist file into `~/Library/LaunchAgents`
To start the service:
`launchctl start ~/Library/LaunchAgents/me.ricterz.bgmi.plist`
To stop the service:
`launchctl stop ~/Library/LaunchAgents/me.ricterz.bgmi.plist`
To enable the service:
`launchctl load ~/Library/LaunchAgents/me.ricterz.bgmi.plist`
To disable the service:
`launchctl unload ~/Library/LaunchAgents/me.ricterz.bgmi.plist`