### PR TITLE
用bangumi_id做为followed表的主键

### DIFF
--- a/bgmi/lib/cli.py
+++ b/bgmi/lib/cli.py
@@ -282,7 +282,7 @@ def download_manager(ret):
 def fetch_(ret):
     try:
         bangumi_obj = Bangumi.get(name=ret.name)
-        Followed.get(bangumi_name=bangumi_obj.name)
+        Followed.get(bangumi_id=bangumi_obj.id)
     except Bangumi.DoesNotExist:
         print_error('Bangumi {} not exist'.format(ret.name))
         return
@@ -290,7 +290,7 @@ def fetch_(ret):
         print_error('Bangumi {} is not followed'.format(ret.name))
         return
 
-    followed_filter_obj = Followed.get(bangumi_name=ret.name)
+    followed_filter_obj = Followed.get(bangumi_id=bangumi_obj.id)
     print_filter(followed_filter_obj)
 
     print_info('Fetch bangumi {} ...'.format(bangumi_obj.name))

--- a/bgmi/lib/cli.py
+++ b/bgmi/lib/cli.py
@@ -239,7 +239,7 @@ def filter_wrapper(ret):
         print_info('Usable subtitle group: {}'.format(result.data['subtitle_group']))
         print_info('Usable data source: {}'.format(result.data['data_source']))
         print()
-        followed_filter_obj = Followed.get(bangumi_name=result.data['name'])
+        followed_filter_obj = result.data['obj']
         print_filter(followed_filter_obj)
     return result.data
 

--- a/bgmi/lib/controllers.py
+++ b/bgmi/lib/controllers.py
@@ -444,7 +444,7 @@ def update(name, download=None, not_ignore=False):
         updated_bangumi_obj = []
         for i in name:
             try:
-                f = Followed.get(bangumi_name=i)
+                f = Followed.get_by_name(bangumi_name=i)
                 f = model_to_dict(f)
                 updated_bangumi_obj.append(f)
             except DoesNotExist:

--- a/bgmi/lib/controllers.py
+++ b/bgmi/lib/controllers.py
@@ -446,6 +446,7 @@ def update(name, download=None, not_ignore=False):
             try:
                 f = Followed.get_by_name(bangumi_name=i)
                 f = model_to_dict(f)
+                f['bangumi_name'] = i
                 updated_bangumi_obj.append(f)
             except DoesNotExist:
                 print_error('{} is not a followed bangumi'.format(i))

--- a/bgmi/lib/models/__init__.py
+++ b/bgmi/lib/models/__init__.py
@@ -27,7 +27,7 @@ def get_updating_bangumi_with_data_source(status=None, order=True):
     common_cond = ((Bangumi.status == Bangumi.STATUS.UPDATING) & (Bangumi.has_data_source == 1))
 
     query = Bangumi.select(Followed.status, Followed.episode, Bangumi) \
-        .join(Followed, pw.JOIN.LEFT_OUTER, on=(Bangumi.name == Followed.bangumi_name))
+        .join(Followed, pw.JOIN.LEFT_OUTER, on=(Bangumi.id == Followed.bangumi_id))
 
     if status is None:
         data = query.where(common_cond)
@@ -47,7 +47,7 @@ def get_updating_bangumi_with_data_source(status=None, order=True):
 def get_followed_bangumi():
     common_cond = ((Bangumi.status == Bangumi.STATUS.UPDATING) & (Bangumi.has_data_source == 1))
     data = Followed.select(Followed, Bangumi, Bangumi.id) \
-        .join(Bangumi, pw.JOIN.LEFT_OUTER, on=(Bangumi.name == Followed.bangumi_name),)\
+        .join(Bangumi, pw.JOIN.LEFT_OUTER, on=(Bangumi.id == Followed.bangumi_id))\
         .where(common_cond).dicts()
     weekly_list = order_by_weekday(data)
     return weekly_list

--- a/bgmi/lib/models/_db.py
+++ b/bgmi/lib/models/_db.py
@@ -15,6 +15,12 @@ class NeoDB(pw.Model):
         database = db
 
     @classmethod
+    def has_status(cls, status):
+        print(status in list(map(int, cls.STATUS)))
+
+
+class FuzzyMixIn:
+    @classmethod
     def fuzzy_get(cls: Type[T], **filters) -> 'T':
         q = []
         for key, value in filters.items():
@@ -23,7 +29,3 @@ class NeoDB(pw.Model):
         if not o:
             raise cls.DoesNotExist
         return o[0]
-
-    @classmethod
-    def has_status(cls, status):
-        print(status in list(map(int, cls.STATUS)))

--- a/bgmi/website/__init__.py
+++ b/bgmi/website/__init__.py
@@ -97,7 +97,6 @@ def get_bgm_tv_calendar() -> list:
             # day['items'][index] = \
             bangumi_tv_weekly_list.append(
                 Bangumi(
-                    id=item['id'],
                     name=html.unescape(name),
                     cover=images.get('large', images.get('common')) or '',
                     status=Bangumi.STATUS.UPDATING,
@@ -247,7 +246,7 @@ class DataSource:
         :type bangumi: bgmi.lib.models._tables.Bangumi
         """
         followed_filter_obj, _ = Followed.get_or_create(
-            bangumi_name=bangumi.name
+            bangumi_id=bangumi.id
         )  # type : (Filter, bool)
 
         data = [

--- a/tests/data/models/main_followed.json
+++ b/tests/data/models/main_followed.json
@@ -1,6 +1,6 @@
 [
   {
-    "bangumi_name": "海贼王",
+    "bangumi_id": 49,
     "episode": 0,
     "status": 1,
     "updated_time": null,
@@ -11,7 +11,7 @@
     "regex": ""
   },
   {
-    "bangumi_name": "名侦探柯南",
+    "bangumi_id": 41,
     "episode": 0,
     "status": 2,
     "updated_time": null,

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -23,7 +23,7 @@ class ControllersTest(Base, unittest.TestCase):
     bangumi_name_2 = '海贼王'  # followed bangumi
 
     def get_followed_obj(self):
-        return Followed.fuzzy_get(bangumi_name=self.bangumi_name_2)
+        return Followed.get_by_name(bangumi_name=self.bangumi_name_2)
 
     def test_cal(self):
         r = bgmi.lib.controllers.cal()
@@ -42,21 +42,21 @@ class ControllersTest(Base, unittest.TestCase):
         r = bgmi.lib.controllers.add(self.bangumi_name_1, 0)
         self.assertEqual(r['status'], 'success')
 
-        f = Followed.get(bangumi_name=self.bangumi_name_1)  # type: Followed
+        f = Followed.get_by_name(bangumi_name=self.bangumi_name_1)  # type: Followed
         self.assertEqual(f.status, Followed.STATUS.FOLLOWED)
 
     def test_add_dupe_warning(self):
         r = bgmi.lib.controllers.add(self.bangumi_name_2, 0)
         self.assertEqual(r['status'], 'warning')
 
-        f = Followed.get(bangumi_name=self.bangumi_name_2)  # type: Followed
+        f = Followed.get_by_name(bangumi_name=self.bangumi_name_2)  # type: Followed
         self.assertEqual(f.status, Followed.STATUS.FOLLOWED)
 
     def test_add_with_episode(self):
 
         r = bgmi.lib.controllers.add(self.bangumi_name_1, episode=4)
         self.assertEqual(r['status'], 'success')
-        f = Followed.get(bangumi_name=self.bangumi_name_1)  # type: Followed
+        f = Followed.get_by_name(bangumi_name=self.bangumi_name_1)  # type: Followed
         self.assertEqual(f.status, Followed.STATUS.FOLLOWED)
         self.assertEqual(f.episode, 4)
 
@@ -150,7 +150,7 @@ class ControllersTest(Base, unittest.TestCase):
         self.assertEqual(result.status, ControllerResult.success)
         self.assertEqual(result.data['followed'], [self.valid_subtitle])
 
-        followed_obj = Followed.fuzzy_get(bangumi_name=self.bangumi_name_2)
+        followed_obj = Followed.get_by_name(bangumi_name=self.bangumi_name_2)
         self.assertEqual(followed_obj.subtitle, [self.valid_subtitle])
 
         result = controllers.filter_(self.bangumi_name_2)
@@ -167,7 +167,7 @@ class ControllersTest(Base, unittest.TestCase):
         )
         self.assertEqual(result.status, ControllerResult.error, result.message)
 
-        followed_obj = Followed.fuzzy_get(bangumi_name=self.bangumi_name_2)
+        followed_obj = Followed.get_by_name(bangumi_name=self.bangumi_name_2)
         self.assertEqual(followed_obj.data_source, [])
 
         result = controllers.filter_(self.bangumi_name_2)
@@ -189,7 +189,7 @@ class ControllersTest(Base, unittest.TestCase):
             result.message,
         )
 
-        followed_obj = Followed.fuzzy_get(bangumi_name=self.bangumi_name_2)
+        followed_obj = Followed.get_by_name(bangumi_name=self.bangumi_name_2)
         self.assertEqual(followed_obj.data_source, [self.valid_data_source])
 
         result = controllers.filter_(self.bangumi_name_2)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -106,27 +106,29 @@ class BangumiTest(Base, TestCase):
         name_updating = []
         for i in range(5):
             name = self.faker.name()
-            Bangumi.create(
+            bangumi_obj = Bangumi.create(
                 name=name,
                 keyword=name,
                 cover=name,
                 update_time='mon',
                 status=Bangumi.STATUS.UPDATING
             )
-            Followed.create(bangumi_name=name, updated_time=now + i)
+            Followed.create(bangumi_id=bangumi_obj.id, updated_time=now + i)
             name_updating.append(name)
 
         name_end = []
         for i in range(5):
             name = self.faker.name()
-            Bangumi.create(
+            bangumi_obj = Bangumi.create(
                 name=name,
                 keyword=name,
                 cover=name,
                 update_time='mon',
                 status=models.Bangumi.STATUS.UPDATING
             )
-            Followed.create(bangumi_name=name, updated_time=now - 2 * 2 * 7 * 24 * 3600 - 200)
+            Followed.create(
+                bangumi_id=bangumi_obj.id, updated_time=now - 2 * 2 * 7 * 24 * 3600 - 200
+            )
             name_end.append(name)
 
         Bangumi.delete_all()
@@ -178,8 +180,7 @@ class BangumiTest(Base, TestCase):
 
 class FollowedTest(Base, TestCase):
     def test_delete_followed(self):
-        name = self.faker.name()
-        Followed.create(bangumi_name=name)
+        Followed.create(bangumi_id=233)
         with patch('builtins.input', Mock(return_value='n')) as m:
             Followed.delete_followed(batch=False)
             m.assert_any_call('[+] are you sure want to CLEAR ALL THE BANGUMI? (y/N): ')


### PR DESCRIPTION
原本用的是bangumi_name，但是可能因为escape之类的原因而导致番剧名发生修改，但对应的番剧还是同一个
如果像原来一样的话， 会导致原来的followed失效，而且bangumi_name也是重复的消息，所以，改为用bangumi_id做为主键。

BREAKCHANGE：因为修改了followed的表结构，用sqlite3删掉followed表然后使用`bgmi install`重新初始化数据库即可。
