### PR TITLE
fix bgmi search for mikan,dmhy

### DIFF
--- a/bgmi/website/mikan.py
+++ b/bgmi/website/mikan.py
@@ -217,17 +217,19 @@ class Mikanani(BaseWebsite):
             title = tr.find("a", class_="magnet-link-wrap").text
             time_string = tr.find_all("td")[2].string
             result.append(
-                {
-                    "download": tr.find("a", class_="magnet-link").attrs.get(
-                        "data-clipboard-text", ""
-                    ),
-                    "name": keyword,
-                    "title": title,
-                    "episode": self.parse_episode(title),
-                    "time": int(
-                        time.mktime(time.strptime(time_string, "%Y/%m/%d %H:%M"))
-                    ),
-                }
+                Episode(
+                    **{
+                        "download": tr.find("a", class_="magnet-link").attrs.get(
+                            "data-clipboard-text", ""
+                        ),
+                        "name": keyword,
+                        "title": title,
+                        "episode": self.parse_episode(title),
+                        "time": int(
+                            time.mktime(time.strptime(time_string, "%Y/%m/%d %H:%M"))
+                        ),
+                    }
+                )
             )
         return result
 

--- a/bgmi/website/share_dmhy.py
+++ b/bgmi/website/share_dmhy.py
@@ -161,13 +161,13 @@ class DmhySource(BaseWebsite):
                 time = int(Time.mktime(Time.strptime(time_string, "%Y/%m/%d %H:%M")))
 
                 result.append(
-                    {
-                        "name": name,
-                        "title": title,
-                        "download": download,
-                        "episode": episode,
-                        "time": time,
-                    }
+                    Episode(
+                        name=name,
+                        title=title,
+                        download=download,
+                        episode=episode,
+                        time=time,
+                    )
                 )
 
         return result

--- a/tests/test_data_source.py
+++ b/tests/test_data_source.py
@@ -3,7 +3,7 @@ import pytest
 from bgmi.lib.fetch import DATA_SOURCE_MAP
 from bgmi.website import mikan
 from bgmi.website.base import BaseWebsite
-from bgmi.website.model import SubtitleGroup, WebsiteBangumi
+from bgmi.website.model import Episode, SubtitleGroup, WebsiteBangumi
 
 
 @pytest.mark.parametrize("source", DATA_SOURCE_MAP.keys())
@@ -27,7 +27,10 @@ def test_info(source, data_source_bangumi_name):
 @pytest.mark.parametrize("source", DATA_SOURCE_MAP.keys())
 def test_search(source, data_source_bangumi_name):
     w = DATA_SOURCE_MAP[source]()
-    assert w.search_by_keyword(data_source_bangumi_name[source][0], count=1)
+    search_result = w.search_by_keyword(data_source_bangumi_name[source][0], count=1)
+    assert search_result
+    for episode in search_result:
+        assert isinstance(episode, Episode)
 
 
 def test_mikan_fetch_all_episode():


### PR DESCRIPTION
现在 utils 里的方法全都接收 Episode 的实例，于是乎这两个源的 search_by_keyword 方法返回的 dict 他不认了
报 `[x] 'dict' object has no attribute 'title'`
这个 PR 里将相关两个源的返回都换成了 Episode 实例，同时也修改了相关的单元测试用例。