### PR TITLE
v2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - episode parsing ([#249](https://github.com/BGmi/BGmi/issues/249))
 - parse episode with E prefix in brackets
+- **config**: always read config file as utf-8 ([#257](https://github.com/BGmi/BGmi/issues/257))
+- **update**: catch network error when fetching bangumi info ([#254](https://github.com/BGmi/BGmi/issues/254))
 
 ## [2.1.4](https://github.com/BGmi/BGmi/compare/2.1.3...2.1.4) - 2021-02-08
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "bgmi"
-version = "2.1.4"
+version = "2.1.5"
 description = 'BGmi is a cli tool for subscribed bangumi.'
 authors = ["RicterZ <ricterzheng@gmail.com>"]
 readme = 'README.md'


### PR DESCRIPTION

### Bug Fixes

- episode parsing ([#249](https://github.com/BGmi/BGmi/issues/249))
- parse episode with E prefix in brackets
- **config**: always read config file as utf-8 ([#257](https://github.com/BGmi/BGmi/issues/257))
- **update**: catch network error when fetching bangumi info ([#254](https://github.com/BGmi/BGmi/issues/254))
