### PR TITLE
fix: confusing when episode have multiple video files

### DIFF
--- a/bgmi/front/index.py
+++ b/bgmi/front/index.py
@@ -29,7 +29,11 @@ def get_player(bangumi_name: str) -> Dict[int, Dict[str, str]]:
         else:
             episode = -1
 
-        for bangumi in files:
+        sorted_files = sorted(files,
+                              key=lambda f: os.path.getsize(os.path.join(root, f)),
+                              reverse=True)
+
+        for bangumi in sorted_files:
             if any(bangumi.lower().endswith(x) for x in [".mp4", ".mkv", ".webm"]):
                 video_file_path = os.path.join(base_path, bangumi)
                 video_file_path = os.path.join(

--- a/bgmi/front/index.py
+++ b/bgmi/front/index.py
@@ -29,9 +29,9 @@ def get_player(bangumi_name: str) -> Dict[int, Dict[str, str]]:
         else:
             episode = -1
 
-        sorted_files = sorted(files,
-                              key=lambda f: os.path.getsize(os.path.join(root, f)),
-                              reverse=True)
+        sorted_files = sorted(
+            files, key=lambda f: os.path.getsize(os.path.join(root, f)), reverse=True
+        )
 
         for bangumi in sorted_files:
             if any(bangumi.lower().endswith(x) for x in [".mp4", ".mkv", ".webm"]):


### PR DESCRIPTION
当一集有多个视频文件时，旧的匹配方式（第一个`os.walk`遇到的）可能出错。
如 [60e3c12722aa3e0007cb86a8](https://bangumi.moe/torrent/60e3c12722aa3e0007cb86a8) 包含了正片、PV、预告等等。
替换为按照文件体积大小遍历基本可以解决问题。