### PR TITLE
Fix not found error for `bgmi install` command

### DIFF
--- a/bgmi/utils/__init__.py
+++ b/bgmi/utils/__init__.py
@@ -97,7 +97,7 @@ indicator_map = {
 NPM_REGISTER_DOMAIN = (
     "registry.npmjs.com"
     if os.environ.get("TRAVIS_CI", False)
-    else "registry.npm.taobao.org"
+    else "registry.cnpmjs.org"
 )
 FRONTEND_NPM_URL = f"https://{NPM_REGISTER_DOMAIN}/bgmi-frontend/"
 PACKAGE_JSON_URL = "https://{}/bgmi-frontend/{}".format(


### PR DESCRIPTION
Now, `registery.npm.taobao.org` returns error when trying to download a file from the registry

```json
{
  "error": "[NOT_FOUND] bgmi-frontend@1.1.x not found"
}
```

After my test, only `registry.cnpmjs.org` could [work properly](https://registry.cnpmjs.org/bgmi-frontend/1.1.x) and accessible in China mainland