### PR TITLE
fix: Remove rpc_path setting

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -145,7 +145,6 @@ rpc_url = "127.0.0.1"
 rpc_port = 9091
 rpc_username = "your_username"
 rpc_password = "your_password"
-rpc_path = "/transmission/" # 对应 transmission 配置文件中的`"rpc-url": "/transmission/",`
 
 [qbittorrent]
 rpc_host = "127.0.0.1"

--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ rpc_url = "127.0.0.1"
 rpc_port = 9091
 rpc_username = "your_username"
 rpc_password = "your_password"
-rpc_path = "/transmission/"
 
 [qbittorrent]
 rpc_host = "127.0.0.1"

--- a/bgmi/config.py
+++ b/bgmi/config.py
@@ -57,7 +57,6 @@ class TransmissionConfig(BaseSetting):
     rpc_port: int = int(os.getenv("BGMI_TRANSMISSION_RPC_PORT") or "9091")
     rpc_username: str = os.getenv("BGMI_TRANSMISSION_RPC_USERNAME") or "your_username"
     rpc_password: str = os.getenv("BGMI_TRANSMISSION_RPC_PASSWORD") or "your_password"
-    rpc_path: str = os.getenv("BGMI_TRANSMISSION_RPC_PATH") or "/transmission/"
 
 
 class QBittorrentConfig(BaseSetting):

--- a/bgmi/downloader/transmission.py
+++ b/bgmi/downloader/transmission.py
@@ -11,7 +11,6 @@ class TransmissionRPC(BaseDownloadService):
             port=cfg.transmission.rpc_port,
             username=cfg.transmission.rpc_username,
             password=cfg.transmission.rpc_password,
-            path=cfg.transmission.rpc_path,
         )
 
     @staticmethod


### PR DESCRIPTION
```toml
[transmission]
rpc_url = "127.0.0.1:9091/tr/rpc"
rpc_port = 9091
rpc_username = "your_username"
rpc_password = "your_password"
```
这样即可完成 `rpc_path` 的设置。

https://github.com/BGmi/BGmi/issues/432