### PR TITLE
Fix/scripts episode update

### DIFF
--- a/bgmi/lib/models.py
+++ b/bgmi/lib/models.py
@@ -271,4 +271,12 @@ def recreate_source_relatively_table() -> None:
         Download,
     ]  # type: List[Type[NeoDB]]
     for table in table_to_drop:
-        table.delete().execute()
+        table.delete().execute()  # pylint: disable=no-value-for-parameter
+
+
+def recreate_scripts_table() -> None:
+    table_to_drop = [
+        Scripts,
+    ]  # type: List[Type[NeoDB]]
+    for table in table_to_drop:
+        table.delete().execute()  # pylint: disable=no-value-for-parameter

--- a/bgmi/script.py
+++ b/bgmi/script.py
@@ -110,6 +110,12 @@ class ScriptRunner:
                     if i == e["episode"]:
                         download_queue.append(e)
 
+            print_success(f"{script.bangumi_name} updated, episode: {episode}")
+            script_obj.episode = episode
+            script_obj.status = STATUS_UPDATED
+            script_obj.updated_time = int(time.time())
+            script_obj.save()
+
             if return_:
                 self.download_queue.extend(Episode(**x) for x in download_queue)
                 continue
@@ -117,12 +123,6 @@ class ScriptRunner:
             if download:
                 print_success(f"Start downloading of {script}")
                 download_prepare([Episode(**x) for x in download_queue])
-
-            print_success(f"{script.bangumi_name} updated, episode: {episode}")
-            script_obj.episode = episode
-            script_obj.status = STATUS_UPDATED
-            script_obj.updated_time = int(time.time())
-            script_obj.save()
 
         return self.download_queue
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import requests_cache
 import urllib3
 
 from bgmi.config import IS_WINDOWS, cfg
-from bgmi.lib.models import recreate_source_relatively_table
+from bgmi.lib.models import recreate_scripts_table, recreate_source_relatively_table
 
 
 def pytest_addoption(parser):
@@ -64,9 +64,11 @@ def data_source_subtitle_name():
 
 @pytest.fixture()
 def _clean_bgmi():
+    recreate_scripts_table()
     recreate_source_relatively_table()
     yield
     recreate_source_relatively_table()
+    recreate_scripts_table()
 
 
 @pytest.fixture()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import pytest
 
 from bgmi.lib.models import Bangumi, Filter, Followed
 from bgmi.main import main_for_test
+from bgmi.script import ScriptRunner
 from bgmi.website.bangumi_moe import BangumiMoe
 
 
@@ -38,6 +39,13 @@ def test_add(bangumi_names):
 def test_update(bangumi_names):
     main_for_test(["add", *bangumi_names])
     main_for_test(["update"])
+
+
+@pytest.mark.usefixtures("_clean_bgmi")
+def test_update_script():
+    main_for_test(["update"])
+    script_obj = ScriptRunner().get_model("TEST_BANGUMI")
+    assert script_obj.episode == 3, "TEST_BANGUMI from script_example.py episode should be 3 after update"
 
 
 @pytest.mark.usefixtures("_clean_bgmi")


### PR DESCRIPTION
脚本订阅的剧集在 update 命令更新的时候不能更新当前最新集数，那段更新脚本实体信息的代码被放在了个永远执行不到的地方。
这个提交里将那段代码上移到会被执行到的位置，并且加上了相关测试。