### PR TITLE
fix(dmhy): escaped characters in bangumi title

### DIFF
--- a/bgmi/website/share_dmhy.py
+++ b/bgmi/website/share_dmhy.py
@@ -57,7 +57,7 @@ def parse_bangumi_with_week_days(content, update_time, array_name) -> List[Websi
 
             bangumi.subtitle_group.append(SubtitleGroup(id=subtitle_group_id, name=subtitle_group_name))
 
-        name = re.sub("\\\\\\'", "'", name)
+        name = re.sub(r"\\'", "'", name)
         bangumi.name = name
         bangumi.update_time = update_time
         bangumi.keyword = keyword

--- a/bgmi/website/share_dmhy.py
+++ b/bgmi/website/share_dmhy.py
@@ -57,6 +57,7 @@ def parse_bangumi_with_week_days(content, update_time, array_name) -> List[Websi
 
             bangumi.subtitle_group.append(SubtitleGroup(id=subtitle_group_id, name=subtitle_group_name))
 
+        name = re.sub("\\\\\\'", "'", name)
         bangumi.name = name
         bangumi.update_time = update_time
         bangumi.keyword = keyword


### PR DESCRIPTION
**问题：** 修复从dmhy源获取的番组标题中存在错误的转义字符
**出现问题的情况：** 在使用dmhy源订阅《BanG Dream! It's MyGO!!!!!》时，由于读入了转义字符，会导致后期下载的文件路径存在反斜杠。此时webui会出错，无法在webui上播放。

![image](https://github.com/BGmi/BGmi/assets/8838409/fd0f64cc-98c6-42e8-bf4b-73c6ec7fa25f)

**原因：** 由于dmhy的新番时间表是从网页中爬出来的，所以在处理番组名称的时候会把JavaScript的转义字符读进来。
爬虫解析到的名称 `It\'s MyGO` -> webui中a标签的名称 `It\s MyGO` ->  浏览器自动转义 `It/s MyGO`
导致\被解析为目录层级，webui无法正确显示内容。

**修复方法：** 在dmhy的处理文件中，将被转义的单引号修正回来。


