### PR TITLE
Add HookRunner

### DIFF
--- a/bgmi/config.py
+++ b/bgmi/config.py
@@ -107,6 +107,7 @@ class Config(BaseSetting):
 
     db_path: pathlib.Path = Path(os.getenv("BGMI_DB_PATH") or str(BGMI_PATH.joinpath("bangumi.db")))
     script_path: pathlib.Path = Path(os.getenv("BGMI_SCRIPT_PATH") or str(BGMI_PATH.joinpath("scripts")))
+    hook_path: pathlib.Path = Path(os.getenv("BGMI_HOOK_PATH") or str(BGMI_PATH.joinpath("hooks")))
     tools_path: pathlib.Path = Path(os.getenv("BGMI_TOOLS_PATH") or str(BGMI_PATH.joinpath("tools")))
 
     max_path: int = 3

--- a/bgmi/lib/controllers.py
+++ b/bgmi/lib/controllers.py
@@ -12,6 +12,8 @@ from bgmi.lib.download import Episode, download_prepare
 from bgmi.lib.fetch import website
 from bgmi.lib.models import (
     FOLLOWED_STATUS,
+    POST_DOWNLOAD,
+    PRE_DOWNLOAD,
     STATUS_DELETED,
     STATUS_FOLLOWED,
     STATUS_NOT_DOWNLOAD,
@@ -25,7 +27,7 @@ from bgmi.lib.models import (
     model_to_dict,
     recreate_source_relatively_table,
 )
-from bgmi.script import ScriptRunner
+from bgmi.script import HookRunner, ScriptRunner
 from bgmi.utils import (
     COLOR_END,
     GREEN,
@@ -380,6 +382,9 @@ def update(names: List[str], download: Optional[bool] = False, not_ignore: bool 
             except DoesNotExist:
                 pass
 
+    if download:
+        HookRunner().run(PRE_DOWNLOAD)
+
     runner = ScriptRunner()
     script_download_queue = runner.run()
     if script_download_queue and download:
@@ -440,6 +445,9 @@ def update(names: List[str], download: Optional[bool] = False, not_ignore: bool 
         if failed:
             print_info("try to re-downloading previous failed torrents ...")
             download_prepare(failed)
+
+    if download:
+        HookRunner().run(POST_DOWNLOAD)
 
     return result
 

--- a/bgmi/lib/models.py
+++ b/bgmi/lib/models.py
@@ -29,6 +29,10 @@ STATUS_DOWNLOADING = 1
 STATUS_DOWNLOADED = 2
 DOWNLOAD_STATUS = (STATUS_NOT_DOWNLOAD, STATUS_DOWNLOADING, STATUS_DOWNLOADED)
 
+# hook stage
+PRE_DOWNLOAD = 0
+POST_DOWNLOAD = 1
+
 DoesNotExist = peewee.DoesNotExist
 
 db = peewee.SqliteDatabase(cfg.db_path)

--- a/bgmi/script.py
+++ b/bgmi/script.py
@@ -229,7 +229,7 @@ class ScriptBase:
 
 class HookRunner:
     _defined = None
-    hook_stage_script = {}
+    hook_stage_script = {}  # type: Dict[int, List[types.FunctionType]]
 
     def __new__(cls, *args, **kwargs):  # type: ignore
         if cls._defined is None:
@@ -252,7 +252,7 @@ class HookRunner:
 
         return cls._defined
 
-    def run(self, stage):
+    def run(self, stage: int) -> None:
         for hook in self.hook_stage_script.get(stage, []):
             hook()
 

--- a/bgmi/script.py
+++ b/bgmi/script.py
@@ -227,6 +227,36 @@ class ScriptBase:
             return {}
 
 
+class HookRunner:
+    _defined = None
+    hook_stage_script = {}
+
+    def __new__(cls, *args, **kwargs):  # type: ignore
+        if cls._defined is None:
+            hook_files = glob.glob(f"{cfg.hook_path}{os.path.sep}*.py")
+            for i in hook_files:
+                try:
+                    loader = SourceFileLoader("hook", os.path.join(cfg.hook_path, i))
+                    mod = types.ModuleType(loader.name)
+                    loader.exec_module(mod)
+                    hook_stage = mod.hook_stage
+                    hook_function = mod.run
+                    cls.hook_stage_script.setdefault(hook_stage, []).append(hook_function)
+                except Exception:
+                    print_warning(f"Load hook {i} failed, ignored")
+                    if os.getenv("DEBUG_SCRIPT"):  # pragma: no cover
+                        traceback.print_exc()
+                    continue
+
+            cls._defined = super().__new__(cls, *args, **kwargs)
+
+        return cls._defined
+
+    def run(self, stage):
+        for hook in self.hook_stage_script.get(stage, []):
+            hook()
+
+
 if __name__ == "__main__":
     runner = ScriptRunner()
     runner.run()


### PR DESCRIPTION

从 #786 拆封出来

基于ScriptRunner改了一个HookRunner，这个hook runner可以在下载前和下载后执行一些东西

我用来直接在提交给qbit下载后根据文件名进行重命名，变成成 `S01/xxx S01Exx.mkv` 的形式，可以直接被emby、jellyfin更好地进行刮削。因为如果要在下载时就重命名好，好像需要对里面许多东西进行大量重构，不如单独针对特定的来一点点修，这个也不会针对每一个episode就新建一个文件夹

放在 `~/.bgmi/hooks` 下面即可

<details><summary>给qbit用的重命名hook</summary>

```python
from typing import List
import qbittorrentapi
import re
from os.path import join, exists
import time
import os
from loguru import logger
from bgmi.config import cfg
from bgmi.lib.models import POST_DOWNLOAD

import pathlib


hook_stage = POST_DOWNLOAD


def run():
    bgmi_save_path = str(cfg.save_path).rstrip('/')

    try:
        client = qbittorrentapi.Client(
            host=cfg.qbittorrent.rpc_host,
            port=cfg.qbittorrent.rpc_port,
            username=cfg.qbittorrent.rpc_username,
            password=cfg.qbittorrent.rpc_password,
        )
        client.auth_log_in()
    except Exception as e:
        logger.exception(e)
        return

    info = list(client.torrents_info(sort="added_on", category=cfg.qbittorrent.category))

    save_path_pattern = re.compile(rf'{bgmi_save_path}/(.*)/(\d+)')

    path_to_remove: List[pathlib.Path] = []

    for torrent in info:
        original_save_path = torrent.save_path

        if original_save_path.startswith(bgmi_save_path):
            m = save_path_pattern.search(original_save_path)

            if m is None:
                continue

            bangumi_name, episode = m.groups()
            episode = int(episode)

            torrent_hash = torrent.hash
            torrent_files = client.torrents_files(torrent_hash)

            assert len(
                torrent_files) == 1, f"Count: {len(torrent_files)}, items: {torrent_files}"
            file = torrent_files[0]

            client.torrents_rename_file(
                torrent_hash=torrent_hash,
                old_path=file.name,
                new_path=f'S01/{bangumi_name} - S01E{episode:02}{file.name[file.name.rfind("."):]}')

            client.torrents_setSavePath(
                join(bgmi_save_path, bangumi_name), torrent_hashes=torrent_hash)

            path_to_remove.append(original_save_path)

    while True:
        logger.info('Waiting for qBittorrent to finish renaming...')
        done = True
        info = list(client.torrents_info(sort="added_on"))
        for torrent in info:
            original_save_path = torrent.save_path

            if original_save_path.startswith(bgmi_save_path):
                m = save_path_pattern.search(original_save_path)

                if m is None:
                    continue
                done = False
        time.sleep(1)
        if done:
            break

    path_to_remove = [pathlib.Path(path) for path in path_to_remove]
    logger.info(f'Path to be removed: {path_to_remove}')

    for path in path_to_remove:
        if exists(path):
            logger.info(f'Removing: {path}')
            try:
                path.rmdir()
            except OSError as e:
                logger.exception(e)

    for path, _, _ in os.walk(bgmi_save_path, topdown=False):
        if len(os.listdir(path)) == 0:
            logger.info(f'Cleanning empty folder {path}')
            os.rmdir(path)

```


</details>