### PR TITLE
Ensure test script directory exists in pytest setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ def pytest_sessionstart(session):
 
 def ensure_example_script():
     test_script = "script_example.py"
+    os.makedirs(cfg.script_path, exist_ok=True)
     p = os.listdir(cfg.script_path)
     if test_script not in p:
         print("copy script_example.py to SCRIPT_PATH")


### PR DESCRIPTION
## Summary

This creates `cfg.script_path` before pytest lists that directory, so tests can start from a fresh `BGMI_PATH` without a pre-existing `scripts/` directory.

## Tests

- `BGMI_PATH=<empty-test-home> pytest tests/test_utils.py tests/test_models.py`
- `python -m py_compile tests/conftest.py`
- `ruff check tests/conftest.py`
- `black --check tests/conftest.py`
- `git diff --check`

`tests/test_http_api.py` now gets past session setup in a fresh `BGMI_PATH`, but still fails on an existing database setup issue (`no such table: scripts`) outside this change.
