### PR TITLE
Fix v5 install, player path, and episode parsing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,30 +12,23 @@ BGmi 是一个用来追番的命令行程序。
 
 ### V5
 
-#### 设计哲学变更
+v5 是一次主要版本更新，重点是更可靠的单集追踪、更适合媒体库的下载整理，以及新的 HTTP/MCP 管理接口。
 
-v4 及之前的版本采用「最大集数」标量模型：BGmi 只记录每部番剧"当前下载到了第几集"。如果第 5 集下载失败，用户需要 `mark` 回第 4 集，然后 `update` 重新从第 5 集开始下载——这会连带重新处理第 5 集之后所有已下载的集数。
+#### 主要变化
 
-v5 改为**集合模型**：BGmi 独立记录每一集的下载状态。某集失败只需 `seen forget` 移除该集记录，`update` 时只会补下载缺失的那一集，不影响其余集数。
+- 改为按单集记录下载状态。单集下载失败时，可用 `seen forget` 重新加入更新队列，不再需要回退整部番剧的进度。
+- 新增 `seen mark` / `seen forget`，用于手动添加或移除单集记录。
+- 新增 path formatter 和 `postprocess`，可将下载完成的文件整理为 `SxxExx` 等媒体库常用路径。
+- `add` 支持 `--season`、`--episode-offset`、`--display-name`，用于修正季度、总集数偏移和媒体库显示名。
+- `bgmi_http` 新增 MCP 接口，供 MCP 客户端管理订阅、过滤器、更新和下载状态。
+- `bgmi install` 支持从 GitHub Release 安装新版前端。
 
-这一变更带来以下影响：
+#### 不兼容变化
 
-- 移除 `mark` 命令（标量模型的产物，不再需要）。
-- 新增 `seen forget` / `seen mark` 命令，精确移除或添加单集下载记录。
-- `update` 命令总是执行下载，移除了已废弃的 `--download` 参数。
-
-#### 新功能
-
-- **MCP（Model Context Protocol）支持**：`bgmi_http` 内置 MCP SSE 服务端，AI Agent（Claude Desktop、Cursor、Cline 等）可直接通过 MCP 协议管理追番订阅。详见[MCP 章节](#mcpmodel-context-protocol支持)。
-- **Path Formatter**：支持自定义下载文件的目录组织格式（如 `{name}/S{season:02d}/E{episode:02d}.{suffix}`），对 Jellyfin 等媒体服务器友好。
-- **Season 管理**：`bgmi add --season` 可在订阅时指定季度号（自动从标题解析，或手动覆盖）。对已订阅番剧同样有效。
-- **下载后处理**：`bgmi postprocess` 命令，将完成的下载按 formatter 规则移动到目标路径。
-
-#### 架构变更
-
-- 重构 bgmi_http：Tornado → Starlette／FastAPI／Uvicorn。
-- ORM 迁移：Peewee → SQLAlchemy 2.0。
-- 移除 `/resource/feed.xml`。
+- Python 版本要求提升到 3.11+。
+- `mark` 命令由 `seen mark` / `seen forget` 取代。
+- `update` 现在默认执行下载，不再使用旧的 `--download` 参数。
+- v4 数据库需要在升级后运行 `bgmi upgrade` 完成迁移。
 
 ---
 
@@ -83,10 +76,22 @@ v5 改为**集合模型**：BGmi 独立记录每一集的下载状态。某集�
 pipx install bgmi
 ```
 
+安装 v5 预发布版本：
+
+```bash
+pipx install "bgmi==5.0.0a4"
+```
+
 ### 使用 pip 安装稳定版本
 
 ```bash
 pip install bgmi
+```
+
+使用 pip 安装 v5 预发布版本：
+
+```bash
+pip install "bgmi==5.0.0a4"
 ```
 
 ### 从源码安装（不推荐）
@@ -569,7 +574,7 @@ class DataSource(BaseWebsite):
 
 ## MCP（Model Context Protocol）支持
 
-`bgmi_http` 内置了 [MCP](https://modelcontextprotocol.io/) SSE 服务端，允许 AI Agent（如 Claude Desktop、Cursor、Cline 等）直接管理你的追番订阅。
+`bgmi_http` 内置了 [MCP](https://modelcontextprotocol.io/) 服务端，允许 MCP 客户端直接管理追番订阅。
 
 ### 端点
 
@@ -587,19 +592,21 @@ class DataSource(BaseWebsite):
 
 | Tool | 说明 |
 |---|---|
-| `cal` | 获取每周番剧日历 |
-| `list` | 列出所有订阅 |
+| `cal` | 获取当前季度番剧日历 |
+| `list` | 列出我的订阅 |
 | `add` | 订阅番剧（支持 `season` 设置季度，对已订阅番剧同样有效） |
 | `delete` | 取消订阅 |
 | `search` | 搜索番剧 |
+| `update` | 检查更新并下载 |
 | `seen` | 获取已观看集数列表 |
 | `seen_forget` | 移除单集下载记录（触发重新下载） |
 | `seen_mark` | 添加单集下载记录（标记为已观看） |
 | `download` | 手动触发下载 |
+| `download_status` | 查看下载任务状态 |
 | `get_filter` | 获取过滤器配置 |
 | `set_filter` | 设置过滤器 |
-| `get_config` | 获取当前配置 |
-| `set_status` | 设置订阅状态 |
+| `postprocess` | 整理已完成下载 |
+| `set_status` | 修正订阅生命周期状态 |
 
 ### Agent 接入配置
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ v5 是一次主要版本更新，重点是更可靠的单集追踪、更适合�
 
 - 改为按单集记录下载状态。单集下载失败时，可用 `seen forget` 重新加入更新队列，不再需要回退整部番剧的进度。
 - 新增 `seen mark` / `seen forget`，用于手动添加或移除单集记录。
-- 新增 path formatter 和 `postprocess`，可将下载完成的文件整理为 `SxxExx` 等媒体库常用路径。
+- 新增 path formatter 和 `postprocess`。启用后，下载中的文件会先进入 `.downloads`，完成后整理为 `SxxExx` 等媒体库常用路径。
 - `add` 支持 `--season`、`--episode-offset`、`--display-name`，用于修正季度、总集数偏移和媒体库显示名。
 - `bgmi_http` 新增 MCP 接口，供 MCP 客户端管理订阅、过滤器、更新和下载状态。
 - `bgmi install` 支持从 GitHub Release 安装新版前端。
@@ -162,6 +162,8 @@ download_delegate = "aria2-rpc" # 番剧下载工具（aria2-rpc、transmission-
 tmp_path = "tmp/tmp" # 临时目录
 log_path = "tmp/log" # 日志目录
 save_path = "tmp/bangumi" # 下载番剧保存地址
+enable_path_formatter = false # 启用后，完成下载会整理为 path_formatter 指定的路径
+path_formatter = "{name}/S{season:02d}/S{season:02d}E{episode:02d}.{suffix}" # 媒体库文件路径格式
 max_path = 3 # 抓取数据时每个番剧最大抓取页数
 bangumi_moe_url = "https://bangumi.moe"
 share_dmhy_url = "https://share.dmhy.org"
@@ -318,6 +320,18 @@ bgmi delete "Re:CREATORS"
 ```bash
 bgmi update
 bgmi update "从零开始的魔法书"
+```
+
+### 下载目录格式
+
+默认情况下，BGmi 仍会把每集下载到 `${save_path}/{番剧名}/{集数}/`。
+
+设置 `enable_path_formatter = true` 后，下载器会先把任务保存到 `${save_path}/.downloads/{任务 ID}/`。任务完成后，`bgmi update` 会自动执行 `postprocess`，也可以手动运行 `bgmi postprocess`，将文件移动到 `path_formatter` 指定的位置。
+
+默认格式为：
+
+```toml
+path_formatter = "{name}/S{season:02d}/S{season:02d}E{episode:02d}.{suffix}"
 ```
 
 ### 管理已下载集数

--- a/bgmi/front/index.py
+++ b/bgmi/front/index.py
@@ -1,41 +1,107 @@
+import glob
 import os
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Iterable, Optional
 
 from bgmi.config import cfg
-from bgmi.utils import bangumi_save_path
+from bgmi.lib.season import strip_season_suffix
+from bgmi.lib.table import Download
+from bgmi.utils import bangumi_save_path, normalize_path
+
+VIDEO_EXTENSIONS = {".mp4", ".mkv", ".avi", ".webm", ".flv", ".rmvb", ".mov", ".ts"}
 
 
-def get_player(bangumi_name: str) -> Dict[int, Dict[str, str]]:
+def get_player(
+    bangumi_name: str,
+    season: int = 1,
+    episode_offset: int = 0,
+    display_name: str = "",
+) -> Dict[int, Dict[str, str]]:
+    if cfg.enable_path_formatter:
+        return get_formatted_player(bangumi_name, season, episode_offset, display_name)
+
+    return get_legacy_player(bangumi_name)
+
+
+def get_legacy_player(bangumi_name: str) -> Dict[int, Dict[str, str]]:
     bangumi_path = bangumi_save_path(bangumi_name)
 
     if not bangumi_path.exists():
         return {}
 
-    episode_list = {}
+    episode_list: Dict[int, Dict[str, str]] = {}
 
-    episodes = [episode.name for episode in bangumi_path.iterdir() if episode.name.isdigit()]
-
-    for episode in episodes:
-        e = find_largest_video_file(bangumi_path.joinpath(episode))
+    for episode in bangumi_path.iterdir():
+        if not episode.is_dir() or not episode.name.isdigit():
+            continue
+        e = find_largest_video_file(episode)
         if e:
-            episode_list[int(episode)] = {"path": "/" + e}
+            episode_list[int(episode.name)] = {"path": "/" + e}
 
     return episode_list
 
 
-def find_largest_video_file(top_dir: Path) -> Optional[str]:
-    video_files = []
-    for root, _, files in os.walk(top_dir):
-        for file in files:
-            _, ext = os.path.splitext(file)
-            if ext.lower() in [".mp4", ".mkv", ".webm"]:
-                p = Path(root).joinpath(file)
-                video_files.append((p.stat().st_size, p))
+def get_formatted_player(
+    bangumi_name: str,
+    season: int,
+    episode_offset: int,
+    display_name: str,
+) -> Dict[int, Dict[str, str]]:
+    name = display_name or strip_season_suffix(bangumi_name)
+    episode_files: Dict[int, Path] = {}
 
-    if not video_files:
+    downloads = Download.all(Download.bangumi_name == bangumi_name, Download.status == Download.STATUS_DOWNLOADED)
+    for download in downloads:
+        path = find_largest_matching_video_file(
+            cfg.path_formatter.format(
+                name=glob.escape(normalize_path(name)),
+                season=season,
+                episode=download.episode + episode_offset,
+                suffix="*",
+                title=glob.escape(download.title),
+            )
+        )
+        if not path:
+            continue
+
+        current = episode_files.get(download.episode)
+        if current is None or path.stat().st_size > current.stat().st_size:
+            episode_files[download.episode] = path
+
+    return {
+        episode: {"path": "/" + path.relative_to(cfg.save_path).as_posix()}
+        for episode, path in sorted(episode_files.items())
+    }
+
+
+def find_largest_video_file(top_dir: Path) -> Optional[str]:
+    video = find_largest_file(
+        Path(root).joinpath(file)
+        for root, _, files in os.walk(top_dir)
+        for file in files
+        if Path(file).suffix.lower() in VIDEO_EXTENSIONS
+    )
+
+    if not video:
         return None
 
-    video_files.sort(key=lambda x: -x[0])
+    return video.relative_to(cfg.save_path).as_posix()
 
-    return video_files[0][1].relative_to(cfg.save_path).as_posix()
+
+def find_largest_matching_video_file(pattern: str) -> Optional[Path]:
+    return find_largest_file(path for path in cfg.save_path.glob(pattern) if path.suffix.lower() in VIDEO_EXTENSIONS)
+
+
+def find_largest_file(paths: Iterable[Path]) -> Optional[Path]:
+    largest: Optional[Path] = None
+    largest_size = -1
+
+    for path in paths:
+        if not path.is_file():
+            continue
+        size = path.stat().st_size
+        if size > largest_size:
+            largest = path
+            largest_size = size
+
+    return largest

--- a/bgmi/front/index.py
+++ b/bgmi/front/index.py
@@ -5,7 +5,6 @@ from typing import Dict, Iterable, Optional
 
 from bgmi.config import cfg
 from bgmi.lib.season import strip_season_suffix
-from bgmi.lib.table import Download
 from bgmi.utils import bangumi_save_path, normalize_path
 
 VIDEO_EXTENSIONS = {".mp4", ".mkv", ".avi", ".webm", ".flv", ".rmvb", ".mov", ".ts"}
@@ -13,25 +12,27 @@ VIDEO_EXTENSIONS = {".mp4", ".mkv", ".avi", ".webm", ".flv", ".rmvb", ".mov", ".
 
 def get_player(
     bangumi_name: str,
+    episodes: Iterable[int] = (),
     season: int = 1,
     episode_offset: int = 0,
     display_name: str = "",
 ) -> Dict[int, Dict[str, str]]:
     if cfg.enable_path_formatter:
-        return get_formatted_player(bangumi_name, season, episode_offset, display_name)
+        return get_formatted_player(bangumi_name, episodes, season, episode_offset, display_name)
 
-    return get_legacy_player(bangumi_name)
+    return get_legacy_player(bangumi_name, episodes)
 
 
-def get_legacy_player(bangumi_name: str) -> Dict[int, Dict[str, str]]:
+def get_legacy_player(bangumi_name: str, episodes: Iterable[int] = ()) -> Dict[int, Dict[str, str]]:
     bangumi_path = bangumi_save_path(bangumi_name)
 
     if not bangumi_path.exists():
         return {}
 
     episode_list: Dict[int, Dict[str, str]] = {}
+    episode_dirs = [bangumi_path / str(episode) for episode in episodes] or list(bangumi_path.iterdir())
 
-    for episode in bangumi_path.iterdir():
+    for episode in episode_dirs:
         if not episode.is_dir() or not episode.name.isdigit():
             continue
         e = find_largest_video_file(episode)
@@ -43,6 +44,7 @@ def get_legacy_player(bangumi_name: str) -> Dict[int, Dict[str, str]]:
 
 def get_formatted_player(
     bangumi_name: str,
+    episodes: Iterable[int],
     season: int,
     episode_offset: int,
     display_name: str,
@@ -50,23 +52,22 @@ def get_formatted_player(
     name = display_name or strip_season_suffix(bangumi_name)
     episode_files: Dict[int, Path] = {}
 
-    downloads = Download.all(Download.bangumi_name == bangumi_name, Download.status == Download.STATUS_DOWNLOADED)
-    for download in downloads:
+    for episode in episodes:
         path = find_largest_matching_video_file(
             cfg.path_formatter.format(
                 name=glob.escape(normalize_path(name)),
                 season=season,
-                episode=download.episode + episode_offset,
+                episode=episode + episode_offset,
                 suffix="*",
-                title=glob.escape(download.title),
+                title="*",
             )
         )
         if not path:
             continue
 
-        current = episode_files.get(download.episode)
+        current = episode_files.get(episode)
         if current is None or path.stat().st_size > current.stat().st_size:
-            episode_files[download.episode] = path
+            episode_files[episode] = path
 
     return {
         episode: {"path": "/" + path.relative_to(cfg.save_path).as_posix()}

--- a/bgmi/front/mcp_server.py
+++ b/bgmi/front/mcp_server.py
@@ -80,14 +80,16 @@ def _format_timestamp(timestamp: int) -> Optional[str]:
 
 @mcp.tool()
 def cal(force_update: bool = False) -> Dict[str, Any]:
-    """Get the weekly bangumi calendar.
+    """Get the current-season bangumi calendar grouped by weekday.
 
-    Returns currently updating bangumi grouped by weekday.
+    This is the seasonal/quarterly bangumi calendar, not just the user's
+    subscriptions. Use list() when you only need followed subscriptions.
 
     Status values:
         STATUS_NOT_FOLLOWED: In calendar but not subscribed.
         STATUS_FOLLOWED: Subscribed.
         STATUS_UPDATED_TODAY: Subscribed and successfully updated today.
+        STATUS_DELETED: In calendar and previously unsubscribed by the user.
     """
     result = ctl.cal(force_update=force_update)
     calendar: Dict[str, List[Dict[str, Any]]] = {}

--- a/bgmi/front/routes.py
+++ b/bgmi/front/routes.py
@@ -106,6 +106,7 @@ def bangumi_list(t: str) -> Any:
     for item in data:
         item["player"] = get_player(
             item["bangumi_name"],
+            episodes=item.get("episodes", ()),
             season=item.get("season", 1),
             episode_offset=item.get("episode_offset", 0),
             display_name=item.get("display_name", ""),

--- a/bgmi/front/routes.py
+++ b/bgmi/front/routes.py
@@ -104,7 +104,12 @@ def bangumi_list(t: str) -> Any:
     data.reverse()
 
     for item in data:
-        item["player"] = get_player(item["bangumi_name"])
+        item["player"] = get_player(
+            item["bangumi_name"],
+            season=item.get("season", 1),
+            episode_offset=item.get("episode_offset", 0),
+            display_name=item.get("display_name", ""),
+        )
 
     return jsonify(data)
 

--- a/bgmi/lib/controllers.py
+++ b/bgmi/lib/controllers.py
@@ -305,7 +305,7 @@ def seen_forget(name: str, episode: int) -> ControllerResult:
         session.execute(
             sa.update(Download)
             .where(Download.bangumi_name == name, Download.episode == episode)
-            .values(status=Download.STATUS_NOT_DOWNLOAD, task_id=None)
+            .values(status=Download.STATUS_DOWNLOADED, task_id=None)
         )
 
     return {

--- a/bgmi/main.py
+++ b/bgmi/main.py
@@ -68,15 +68,9 @@ def cli(ctx: click.Context) -> None:
 @cli.command("install", help="Install BGmi and frontend.")
 @click.option("--no-web", is_flag=True, default=False, help="Do not download web static files.")
 def install(no_web: bool) -> None:
-    need_to_init = False
-    if not CONFIG_FILE_PATH.exists():
-        need_to_init = True
-
     create_dir()
     init_db()
-    if need_to_init:
-        install_crontab()
-
+    install_crontab()
     write_default_config()
     update_database()
 

--- a/bgmi/utils/__init__.py
+++ b/bgmi/utils/__init__.py
@@ -218,9 +218,11 @@ def check_update(mark: bool = True) -> None:
 
 
 _separator_episode_pattern = re.compile(r"[★☆](?:第\s*)?(?P<episode>0*[1-9]\d{0,2})(?=[\s(（)）\]】★☆_.])")
+_bracketed_release_year_pattern = re.compile(r"[\[【(（]\s*(?:19|20)\d{2}\s*[\]】)）]")
 
 
 def parse_episode(episode_title: str) -> int:
+    episode_title = _bracketed_release_year_pattern.sub("", episode_title)
     s, c = _parse_episode(episode_title)
     if c == 1:
         return s or 0

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -32,6 +32,19 @@ def test_cal_config():
     main_for_test(["config", "--help"])
 
 
+def test_install_refreshes_crontab():
+    with (
+        mock.patch("bgmi.main.create_dir"),
+        mock.patch("bgmi.main.init_db"),
+        mock.patch("bgmi.main.install_crontab") as install_crontab,
+        mock.patch("bgmi.main.write_default_config"),
+        mock.patch("bgmi.main.update_database"),
+    ):
+        main_for_test(["install", "--no-web"])
+
+    install_crontab.assert_called_once()
+
+
 @pytest.mark.usefixtures("_clean_bgmi")
 def test_list_with_empty_seen_episodes():
     Bangumi(id="empty-seen", name="Empty Seen", update_day="Mon").save()

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -267,7 +267,7 @@ def test_seen():
 
 
 @pytest.mark.usefixtures("_ensure_data")
-def test_seen_forget_resets_download_record():
+def test_seen_forget_does_not_mark_download_failed():
     with Session.begin() as tx:
         tx.add(
             Download(
@@ -288,7 +288,7 @@ def test_seen_forget_resets_download_record():
     assert result["total_episode"] == 2
     assert 2 not in Followed.get(Followed.bangumi_name == bangumi_name_1).episodes
     download = Download.get(Download.bangumi_name == bangumi_name_1, Download.episode == 2)
-    assert download.status == Download.STATUS_NOT_DOWNLOAD
+    assert download.status == Download.STATUS_DOWNLOADED
     assert download.task_id is None
 
 

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -1,5 +1,6 @@
 import os
 import random
+import shutil
 import string
 from urllib.parse import quote
 
@@ -11,7 +12,7 @@ from bgmi.config import cfg
 from bgmi.front.index import get_player
 from bgmi.front.routes import COVER_URL
 from bgmi.front.server import make_app
-from bgmi.lib.table import Followed
+from bgmi.lib.table import Download, Followed, Session
 
 
 def random_word(length):
@@ -199,3 +200,35 @@ def test_get_player():
 
     assert 2 in bangumi_dict["player"]
     assert bangumi_dict["player"][2]["path"] == f"/{bangumi_name}/2/2.mkv"
+
+
+def test_get_player_with_path_formatter():
+    bangumi_name = "相反的你和我 第二季"
+    target_dir = cfg.save_path / "相反的你和我" / "S02"
+    old_enable = cfg.enable_path_formatter
+    old_formatter = cfg.path_formatter
+
+    try:
+        cfg.enable_path_formatter = True
+        cfg.path_formatter = "{name}/S{season:02d}/S{season:02d}E{episode:02d}.{suffix}"
+        shutil.rmtree(cfg.save_path / "相反的你和我", ignore_errors=True)
+        target_dir.mkdir(parents=True)
+        (target_dir / "S02E01.mkv").write_text("video")
+
+        with Session.begin() as tx:
+            tx.query(Download).delete()
+            tx.add(
+                Download(
+                    bangumi_name=bangumi_name,
+                    episode=13,
+                    title="episode 13",
+                    download="magnet:?xt=urn:btih:test",
+                    status=Download.STATUS_DOWNLOADED,
+                )
+            )
+
+        assert get_player(bangumi_name, season=2, episode_offset=-12) == {13: {"path": "/相反的你和我/S02/S02E01.mkv"}}
+    finally:
+        cfg.enable_path_formatter = old_enable
+        cfg.path_formatter = old_formatter
+        shutil.rmtree(cfg.save_path / "相反的你和我", ignore_errors=True)

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -12,7 +12,7 @@ from bgmi.config import cfg
 from bgmi.front.index import get_player
 from bgmi.front.routes import COVER_URL
 from bgmi.front.server import make_app
-from bgmi.lib.table import Download, Followed, Session
+from bgmi.lib.table import Followed
 
 
 def random_word(length):
@@ -193,7 +193,7 @@ def test_get_player():
     with open(os.path.join(episode2_dir, "2.mkv"), "a"):
         pass
 
-    bangumi_dict = {"player": get_player(bangumi_name)}
+    bangumi_dict = {"player": get_player(bangumi_name, episodes={1, 2, 3})}
 
     assert 1 in bangumi_dict["player"]
     assert bangumi_dict["player"][1]["path"] == f"/{bangumi_name}/1/episode1/1.mp4"
@@ -213,21 +213,12 @@ def test_get_player_with_path_formatter():
         cfg.path_formatter = "{name}/S{season:02d}/S{season:02d}E{episode:02d}.{suffix}"
         shutil.rmtree(cfg.save_path / "相反的你和我", ignore_errors=True)
         target_dir.mkdir(parents=True)
+        (target_dir / "S02E02.txt").write_text("not video")
         (target_dir / "S02E01.mkv").write_text("video")
-
-        with Session.begin() as tx:
-            tx.query(Download).delete()
-            tx.add(
-                Download(
-                    bangumi_name=bangumi_name,
-                    episode=13,
-                    title="episode 13",
-                    download="magnet:?xt=urn:btih:test",
-                    status=Download.STATUS_DOWNLOADED,
-                )
-            )
-
-        assert get_player(bangumi_name, season=2, episode_offset=-12) == {13: {"path": "/相反的你和我/S02/S02E01.mkv"}}
+        assert get_player(bangumi_name, episodes={13}, season=2, episode_offset=-12) == {
+            13: {"path": "/相反的你和我/S02/S02E01.mkv"}
+        }
+        assert get_player(bangumi_name, episodes={14}, season=2, episode_offset=-12) == {}
     finally:
         cfg.enable_path_formatter = old_enable
         cfg.path_formatter = old_formatter

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@ _episode_cases: List[Tuple[str, int]] = [
         "[YMDR][哥布林殺手][Goblin Slayer][2018][01][1080p][AVC][JAP][BIG5][MP4-AAC][繁中]",
         1,
     ),
+    ("弱弱老师.Yowayowa.Sensei.S01..1080p.UNCENSORED.ADN.WEB-DL [2026]", 0),
     ("【安達與島村】【第二話】【1080P】【繁體中文】【AVC】", 2),
     ("のんのんびより のんすとっぷ 第02话 BIG5 720p MP4", 2),
     ("OVA 噬血狂袭 Strike the Blood IV [E01][720P][GB][BDrip]", 1),


### PR DESCRIPTION
## Summary

- Refresh BGmi cron entries on every `bgmi install` so existing Docker/config installs still get scheduled jobs.
- Resolve Web API player paths from the configured path formatter and followed episode records instead of download history.
- Ignore bracketed release years such as `[2026]` during episode parsing.
- Keep `seen forget` from marking old download records as failed, avoiding stale parser artifacts being retried.
- Clarify v5 download layout and MCP calendar docs.

## Tests

- `uv run pytest tests/test_utils.py::test_episode_parse tests/test_controllers.py::test_seen_forget_does_not_mark_download_failed tests/test_http_api.py::test_get_player tests/test_http_api.py::test_get_player_with_path_formatter tests/test_utils.py::test_get_player`
- pre-commit hooks on commit
