### PR TITLE
fix(config): exclude None values in Config.save() to prevent ConvertError under Pydantic 2

### DIFF
--- a/bgmi/config.py
+++ b/bgmi/config.py
@@ -179,7 +179,7 @@ class Config(BaseSetting):
     )
 
     def save(self) -> None:
-        s = tomlkit.dumps(json.loads(self.model_dump_json()))
+        s = tomlkit.dumps(json.loads(self.model_dump_json(exclude_none=True)))
 
         CONFIG_FILE_PATH.write_text(s, encoding="utf8")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,4 +16,3 @@ def test_config_save_with_none_values(tmp_path):
         assert config_file.exists()
         content = config_file.read_text(encoding="utf8")
         assert len(content) > 0
-

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,19 @@
 from bgmi.config import BGMI_PATH, Config
+from unittest.mock import patch
 
 
 def test_default_log_path_uses_log_directory():
     cfg = Config()
 
     assert cfg.log_path == BGMI_PATH / "log"
+
+
+def test_config_save_with_none_values(tmp_path):
+    cfg = Config()
+    config_file = tmp_path / "config.toml"
+    with patch("bgmi.config.CONFIG_FILE_PATH", config_file):
+        cfg.save()
+        assert config_file.exists()
+        content = config_file.read_text(encoding="utf8")
+        assert len(content) > 0
+


### PR DESCRIPTION
## Summary
Fixes `ConvertError: Unable to convert an object of <class 'NoneType'> to a TOML item` raised by `tomlkit` when calling `Config.save()` on configurations containing `None` values under Pydantic 2.

## Changes
- Updated `Config.save()` in `bgmi/config.py` to dump JSON with `exclude_none=True`.
- Added unit test `test_config_save_with_none_values` in `tests/test_config.py` to verify behavior.