### PR TITLE
fix(webui): enable serve_static_files by default and add frontend installation notice (fixes #1085)

### DIFF
--- a/bgmi/config.py
+++ b/bgmi/config.py
@@ -96,7 +96,14 @@ class HTTP(BaseSetting):
             description="serve static files with main",
             validate_default=True,
         ),
-    ] = cast(bool, os.getenv("BGMI_HTTP_SERVE_STATIC_FILES") or False)
+    ] = cast(
+        bool,
+        (
+            os.getenv("BGMI_HTTP_SERVE_STATIC_FILES").lower() == "true"
+            if os.getenv("BGMI_HTTP_SERVE_STATIC_FILES") is not None
+            else True
+        ),
+    )
 
 
 class Config(BaseSetting):

--- a/bgmi/config.py
+++ b/bgmi/config.py
@@ -98,11 +98,7 @@ class HTTP(BaseSetting):
         ),
     ] = cast(
         bool,
-        (
-            os.getenv("BGMI_HTTP_SERVE_STATIC_FILES").lower() == "true"
-            if os.getenv("BGMI_HTTP_SERVE_STATIC_FILES") is not None
-            else True
-        ),
+        os.getenv("BGMI_HTTP_SERVE_STATIC_FILES", "true").lower() == "true",
     )
 
 

--- a/bgmi/config.py
+++ b/bgmi/config.py
@@ -179,7 +179,7 @@ class Config(BaseSetting):
     )
 
     def save(self) -> None:
-        s = tomlkit.dumps(json.loads(self.model_dump_json()))
+        s = tomlkit.dumps(json.loads(self.model_dump_json(exclude_none=True)))
 
         CONFIG_FILE_PATH.write_text(s, encoding="utf8")
 

--- a/bgmi/front/server.py
+++ b/bgmi/front/server.py
@@ -30,8 +30,8 @@ def main(address: str, port: int) -> None:
 def index_need_config(_: Request) -> HTMLResponse:
     return HTMLResponse(
         "<h1>BGmi HTTP Service</h1>"
-        "<pre>Please modify your web server configure file\n"
-        f"to server this path to '{cfg.save_path}'.\n"
+        "<pre>Please modify your web server configuration file\n"
+        f"to serve this path to '{cfg.save_path}'.\n"
         "e.g.\n\n"
         "...\n"
         "autoindex on;\n"
@@ -42,9 +42,19 @@ def index_need_config(_: Request) -> HTMLResponse:
         f"    alias {cfg.save_path.as_posix()}/;\n"
         "}\n"
         "...\n\n"
-        "If use want main to serve static files, please run this command and <strong>restart main</strong>\n"
+        "If you want main to serve static files, please run this command and <strong>restart main</strong>\n"
         "\n"
         "<code>bgmi config set http serve_static_files --value true</code></pre>"
+    )
+
+
+def index_need_frontend(_: Request) -> HTMLResponse:
+    return HTMLResponse(
+        "<h1>BGmi HTTP Service</h1>"
+        "<pre>BGmi Web UI static files not found.\n"
+        f"Target static directory: '{cfg.front_static_path.as_posix()}'.\n\n"
+        "Please run the following command to download and install BGmi frontend:\n\n"
+        "<code>bgmi install</code></pre>"
     )
 
 
@@ -59,12 +69,11 @@ def make_app(debug: bool = False) -> Starlette:
 
     if cfg.http.serve_static_files:
         print("will handle static files")
-        routes.extend(
-            [
-                Mount("/bangumi", app=StaticFiles(directory=cfg.save_path)),
-                Mount("/", app=StaticFiles(directory=cfg.front_static_path, html=True)),
-            ]
-        )
+        routes.append(Mount("/bangumi", app=StaticFiles(directory=cfg.save_path)))
+        if (cfg.front_static_path / "index.html").exists():
+            routes.append(Mount("/", app=StaticFiles(directory=cfg.front_static_path, html=True)))
+        else:
+            routes.append(Route("/", endpoint=index_need_frontend))
     else:
         routes.extend(
             [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,4 +16,3 @@ def test_config_save_with_none_values(tmp_path):
         assert config_file.exists()
         content = config_file.read_text(encoding="utf8")
         assert len(content) > 0
-

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,19 @@
 from bgmi.config import BGMI_PATH, Config
+from unittest.mock import patch
 
 
 def test_default_log_path_uses_log_directory():
     cfg = Config()
 
     assert cfg.log_path == BGMI_PATH / "log"
+
+
+def test_config_save_with_none_values(tmp_path):
+    cfg = Config()
+    config_file = tmp_path / "config.toml"
+    with patch("bgmi.config.CONFIG_FILE_PATH", config_file):
+        cfg.save()
+        assert config_file.exists()
+        content = config_file.read_text(encoding="utf8")
+        assert len(content) > 0
+

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -318,3 +318,52 @@ def test_get_player_with_path_formatter():
         cfg.enable_path_formatter = old_enable
         cfg.path_formatter = old_formatter
         shutil.rmtree(cfg.save_path / "相反的你和我", ignore_errors=True)
+
+
+def test_serve_static_files_disabled_shows_config_help(tmp_path):
+    old_val = cfg.http.serve_static_files
+    try:
+        cfg.http.serve_static_files = False
+        app = make_app(debug=True)
+        c = TestClient(app)
+        r = c.get("/")
+        assert r.status_code == 200
+        assert "bgmi config set http serve_static_files" in r.text
+    finally:
+        cfg.http.serve_static_files = old_val
+
+
+def test_serve_static_files_enabled_without_frontend_shows_install_help(tmp_path):
+    old_val = cfg.http.serve_static_files
+    old_static_path = cfg.front_static_path
+    try:
+        cfg.http.serve_static_files = True
+        cfg.front_static_path = tmp_path / "empty_static"
+        cfg.front_static_path.mkdir(parents=True, exist_ok=True)
+        app = make_app(debug=True)
+        c = TestClient(app)
+        r = c.get("/")
+        assert r.status_code == 200
+        assert "bgmi install" in r.text
+    finally:
+        cfg.http.serve_static_files = old_val
+        cfg.front_static_path = old_static_path
+
+
+def test_serve_static_files_enabled_with_frontend_serves_index(tmp_path):
+    old_val = cfg.http.serve_static_files
+    old_static_path = cfg.front_static_path
+    try:
+        cfg.http.serve_static_files = True
+        static_dir = tmp_path / "static"
+        static_dir.mkdir(parents=True, exist_ok=True)
+        (static_dir / "index.html").write_text("<h1>BGmi Web UI</h1>")
+        cfg.front_static_path = static_dir
+        app = make_app(debug=True)
+        c = TestClient(app)
+        r = c.get("/")
+        assert r.status_code == 200
+        assert "BGmi Web UI" in r.text
+    finally:
+        cfg.http.serve_static_files = old_val
+        cfg.front_static_path = old_static_path


### PR DESCRIPTION
Fixes #1085

## Summary
Resolves the issue where new users installing BGmi cannot access the Web UI out-of-the-box when running `bgmi_http`.

## Changes
- Updated `serve_static_files` default value to `True` in `bgmi/config.py`.
- Improved static file routing in `bgmi/front/server.py`: when `serve_static_files` is `True` but `index.html` is not present, display a helpful notice guiding users to run `bgmi install`.
- Fixed typos and instructions in `index_need_config`.
- Added unit tests in `tests/test_http_api.py` covering all static file serving scenarios.