### PR TITLE
Read nested values with bgmi config get

### DIFF
--- a/bgmi/main.py
+++ b/bgmi/main.py
@@ -153,7 +153,10 @@ def config_get(keys: List[str]) -> None:
     res = doc
 
     for key in keys:
-        res = doc.get(key, {})
+        if not isinstance(res, Mapping):
+            res = {}
+            break
+        res = res.get(key, {})
 
     print("config", ".".join(keys), res)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,28 @@
 from bgmi.config import BGMI_PATH, Config
+from bgmi.main import config_get
 
 
 def test_default_log_path_uses_log_directory():
     cfg = Config()
 
     assert cfg.log_path == BGMI_PATH / "log"
+
+
+def test_config_get_reads_nested_value(tmp_path, monkeypatch, capsys):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('[http]\nadmin_token = "river-stone-42"\n', encoding="utf-8")
+    monkeypatch.setattr("bgmi.main.CONFIG_FILE_PATH", config_path)
+
+    config_get(["http", "admin_token"])
+
+    assert capsys.readouterr().out == "config http.admin_token river-stone-42\n"
+
+
+def test_config_get_handles_path_below_scalar(tmp_path, monkeypatch, capsys):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("max_path = 4\n", encoding="utf-8")
+    monkeypatch.setattr("bgmi.main.CONFIG_FILE_PATH", config_path)
+
+    config_get(["max_path", "label"])
+
+    assert capsys.readouterr().out == "config max_path.label {}\n"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import pytest
+
 from bgmi.config import BGMI_PATH, Config
 from bgmi.main import config_get
 
@@ -13,8 +15,10 @@ def test_config_get_reads_nested_value(tmp_path, monkeypatch, capsys):
     config_path.write_text('[http]\nadmin_token = "river-stone-42"\n', encoding="utf-8")
     monkeypatch.setattr("bgmi.main.CONFIG_FILE_PATH", config_path)
 
-    config_get(["http", "admin_token"])
+    with pytest.raises(SystemExit) as exc_info:
+        config_get(["http", "admin_token"])
 
+    assert exc_info.value.code == 0
     assert capsys.readouterr().out == "config http.admin_token river-stone-42\n"
 
 
@@ -23,6 +27,8 @@ def test_config_get_handles_path_below_scalar(tmp_path, monkeypatch, capsys):
     config_path.write_text("max_path = 4\n", encoding="utf-8")
     monkeypatch.setattr("bgmi.main.CONFIG_FILE_PATH", config_path)
 
-    config_get(["max_path", "label"])
+    with pytest.raises(SystemExit) as exc_info:
+        config_get(["max_path", "label"])
 
+    assert exc_info.value.code == 0
     assert capsys.readouterr().out == "config max_path.label {}\n"


### PR DESCRIPTION
`bgmi config get http admin_token` restarted each lookup at the document root, so it printed `{}` for nested values. Walk each key from the value found by the previous key, and keep the existing empty result when a path continues below a scalar.

The new tests cover a nested token and an invalid path below `max_path`. A controlled function-level check reproduces the failure on the base commit and passes here. I did not run the full pytest suite because it loads the package's dependency graph outside the isolated test scope.
