### PR TITLE
Compare available BGmi versions numerically

### DIFF
--- a/bgmi/utils/__init__.py
+++ b/bgmi/utils/__init__.py
@@ -19,6 +19,7 @@ import requests
 import semver
 from anime_episode_parser import parse_episode as _parse_episode
 from loguru import logger
+from packaging.version import Version
 from requests import Response
 
 from bgmi import __admin_version__, __version__
@@ -168,6 +169,10 @@ def latest_frontend_version() -> semver.VersionInfo:
         return latest_npm_package_version()
 
 
+def _is_newer_version(available: str, current: str) -> bool:
+    return Version(available) > Version(current)
+
+
 def check_update(mark: bool = True) -> None:
     def update() -> None:
         try:
@@ -178,7 +183,7 @@ def check_update(mark: bool = True) -> None:
             with open(os.path.join(BGMI_PATH, "latest"), "w", encoding="utf8") as f:
                 f.write(version)
 
-            if version > __version__:
+            if _is_newer_version(version, __version__):
                 print_warning(
                     "Please update bgmi to the latest version {}{}{}."
                     "\nThen execute `bgmi upgrade` to migrate database".format(GREEN, version, COLOR_END)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from bgmi.config import cfg
 from bgmi.front.index import get_player
-from bgmi.utils import episode_filter_regex, latest_github_release, parse_episode
+from bgmi.utils import _is_newer_version, episode_filter_regex, latest_github_release, parse_episode
 from bgmi.website.model import Episode
 
 _episode_cases: List[Tuple[str, int]] = [
@@ -129,6 +129,14 @@ def test_latest_github_release_selects_compatible_tgz_asset():
     assert str(version) == "2.1.3"
     assert release["tag_name"] == "v2.1.3"
     assert asset["name"] == "bgmi-frontend-2.1.3.tgz"
+
+
+def test_newer_version_compares_numeric_components():
+    assert _is_newer_version("10.0.0", "9.9.9")
+    assert _is_newer_version("5.0.10", "5.0.9")
+    assert _is_newer_version("5.0.0", "5.0.0b1")
+    assert _is_newer_version("5.0.0b2", "5.0.0b1")
+    assert not _is_newer_version("5.0.9", "5.0.10")
 
 
 def test_get_player():


### PR DESCRIPTION
The update check compared release strings directly, so `10.0.0` was considered older than `9.9.9` and `5.0.10` older than `5.0.9`. Parse both values with the existing PEP 440 version library before comparing them, including BGmi beta versions such as `5.0.0b1`.

Focused checks now cover numeric components, downgrades, and beta-to-final releases. The base comparison fails the major-version case while this commit passes every case. These checks ran in the offline harness; the complete pytest suite was not run.
