### PR TITLE
Parse compound Chinese season numbers

### DIFF
--- a/bgmi/lib/season.py
+++ b/bgmi/lib/season.py
@@ -25,10 +25,12 @@ CN_NUM_MAP: Dict[str, int] = {
 def _cn_to_int(s: str) -> int:
     if s in CN_NUM_MAP:
         return CN_NUM_MAP[s]
-    if s.startswith("十"):
-        return 10 + _cn_to_int(s[1:])
-    if s.endswith("十"):
-        return _cn_to_int(s[:-1]) * 10
+    if s.count("十") == 1:
+        tens, ones = s.split("十")
+        if len(tens) <= 1 and len(ones) <= 1:
+            tens_value = CN_NUM_MAP.get(tens, 1) if tens else 1
+            ones_value = CN_NUM_MAP.get(ones, 0) if ones else 0
+            return tens_value * 10 + ones_value
     return 1
 
 

--- a/tests/test_postprocessor.py
+++ b/tests/test_postprocessor.py
@@ -12,6 +12,8 @@ class TestParseSeason:
         assert parse_season("进击的巨人 第二季") == 2
         assert parse_season("某某某 第十二季") == 12
         assert parse_season("某某某 第三季") == 3
+        assert parse_season("王者天下 第二十一季") == 21
+        assert parse_season("银河英雄传说 第三十二季") == 32
 
     def test_arabic_digit(self):
         assert parse_season("进击的巨人 第2季") == 2


### PR DESCRIPTION
Chinese season names above fifteen matched the season pattern but often fell back to season 1. For example, `第二十一季` and `第三十二季` were both parsed as the first season.

Parse the tens and ones around a single `十` while keeping the current fallback for malformed text. The dependency-free parser check now returns seasons 21 and 32 and still handles season 15. It fails on the base source and passes here; I did not run the rest of the package test suite.
