### PR TITLE
Preserve seen episodes when re-adding an updated subscription

### DIFF
--- a/bgmi/lib/controllers.py
+++ b/bgmi/lib/controllers.py
@@ -103,7 +103,7 @@ def add(
             if resolved_display_name is not None:
                 followed_obj.display_name = resolved_display_name
             session.add(followed_obj)
-        elif followed_obj.status == Followed.STATUS_FOLLOWED:
+        elif followed_obj.status in (Followed.STATUS_FOLLOWED, Followed.STATUS_UPDATED):
             should_set_auto_display_name = auto_display_name is not None and not followed_obj.display_name
             if has_overrides or should_set_auto_display_name:
                 if season is not None:

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -170,6 +170,29 @@ def test_add_can_mark_currently_available_episodes():
     assert Followed.get(Followed.bangumi_name == name).episodes == {1, 2, 3}
 
 
+def test_add_preserves_seen_episodes_after_same_day_update():
+    recreate_source_relatively_table()
+    name = "葬送的芙莉莲"
+    seen_episodes = {2, 5, 8}
+    with Session.begin() as tx:
+        tx.add(Bangumi(id="frieren-s2", name=name, update_day="Fri"))
+        tx.add(
+            Followed(
+                bangumi_name=name,
+                episodes=seen_episodes,
+                status=Followed.STATUS_UPDATED,
+                updated_time=int(datetime.datetime.now().timestamp()),
+            )
+        )
+
+    result = ctl.add(name)
+
+    assert result["status"] == "warning", result["message"]
+    followed = Followed.get(Followed.bangumi_name == name)
+    assert followed.status == Followed.STATUS_UPDATED
+    assert followed.episodes == seen_episodes
+
+
 def test_add_auto_display_name_from_season_suffix():
     recreate_source_relatively_table()
     name = "相反的你和我 第二季"


### PR DESCRIPTION
Re-adding a subscription after it updated earlier the same day treated it like a deleted entry. With the default episode value, that changed its status and cleared every seen episode, allowing old episodes to be queued again.

Treat today's updated state like the other active subscription state. The regression keeps the status and seen episodes for `葬送的芙莉莲`; the same controlled scenario clears them on the base commit. I kept validation offline and did not run the full dependency-backed suite.
